### PR TITLE
Implement dynamic success/cancel URLs for checkout

### DIFF
--- a/app.py
+++ b/app.py
@@ -77,6 +77,10 @@ def book():
 @app.route('/create-checkout-session', methods=['POST'])
 def create_checkout_session():
     try:
+        base_url = os.getenv('BASE_URL') or request.url_root
+        if base_url.endswith('/'):
+            base_url = base_url[:-1]
+
         session = stripe.checkout.Session.create(
             payment_method_types=['card'],
             line_items=[{
@@ -90,8 +94,8 @@ def create_checkout_session():
                 'quantity': 1,
             }],
             mode='payment',
-            success_url='http://localhost:5000/thankyou',
-            cancel_url='http://localhost:5000/',
+            success_url=f"{base_url}/thankyou",
+            cancel_url=f"{base_url}/",
         )
         return redirect(session.url, code=303)
     except Exception as e:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,64 @@
+import os
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import patch
+
+sys.modules['dotenv'] = ModuleType('dotenv')
+sys.modules['dotenv'].load_dotenv = lambda: None
+sys.modules['sendgrid'] = ModuleType('sendgrid')
+sys.modules['sendgrid'].SendGridAPIClient = object
+sys.modules['sendgrid.helpers'] = ModuleType('sendgrid.helpers')
+sys.modules['sendgrid.helpers.mail'] = ModuleType('sendgrid.helpers.mail')
+sys.modules['sendgrid.helpers.mail'].Mail = object
+sys.modules['twilio'] = ModuleType('twilio')
+sys.modules['twilio.rest'] = ModuleType('twilio.rest')
+sys.modules['twilio.rest'].Client = object
+sys.modules['stripe'] = ModuleType('stripe')
+sys.modules['stripe'].checkout = SimpleNamespace(Session=SimpleNamespace(create=None))
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import app
+
+
+def create_client():
+    app.app.config['TESTING'] = True
+    return app.app.test_client()
+
+
+class DummySession:
+    url = 'https://stripe.test/session'
+
+
+@patch('app.stripe.checkout.Session.create')
+def test_create_checkout_session_env_var(mock_create):
+    client = create_client()
+    os.environ['BASE_URL'] = 'https://example.com'
+
+    def fake_create(**kwargs):
+        assert kwargs['success_url'] == 'https://example.com/thankyou'
+        assert kwargs['cancel_url'] == 'https://example.com/'
+        return DummySession()
+
+    mock_create.side_effect = fake_create
+
+    response = client.post('/create-checkout-session')
+    assert response.status_code == 303
+    assert response.headers['Location'] == DummySession.url
+    del os.environ['BASE_URL']
+
+
+@patch('app.stripe.checkout.Session.create')
+def test_create_checkout_session_request_root(mock_create):
+    client = create_client()
+
+    def fake_create(**kwargs):
+        assert kwargs['success_url'] == 'http://localhost/thankyou'
+        assert kwargs['cancel_url'] == 'http://localhost/'
+        return DummySession()
+
+    mock_create.side_effect = fake_create
+
+    response = client.post('/create-checkout-session')
+    assert response.status_code == 303
+    assert response.headers['Location'] == DummySession.url


### PR DESCRIPTION
## Summary
- compute base url from `BASE_URL` env var or request root in `app.py`
- derive Stripe success/cancel URLs from that base
- add tests covering URL generation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684a20975638832b8b8d5ab1f8113961